### PR TITLE
Use Poetry as deps manager

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.1"
 description = ""
 authors = ["Ekaterina Itchenko <ekaterina.savickaya.1989@gmail.com>"]
 readme = "README.md"
-
+package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.13"


### PR DESCRIPTION
The following error occurs when building the project.

<img width="1020" height="121" alt="Screenshot 2025-09-29 at 9 32 07 PM" src="https://github.com/user-attachments/assets/bf668e27-5be8-430c-9aac-7ff52078b2d8" />

From what I understand, Poetry is currently being used as the dependency manager. This issue can be resolved by setting `package-mode = false`. After that, the error should disappear, and the project can be built successfully using `poetry install` without errors.
